### PR TITLE
Clear site cache when WP Core is upgraded, or an active theme or plugin

### DIFF
--- a/quick-cache/quick-cache.inc.php
+++ b/quick-cache/quick-cache.inc.php
@@ -2032,6 +2032,8 @@ namespace quick_cache
 				{
 					case 'plugin': // Plugin upgrade.
 
+						/** @var $skin \Plugin_Upgrader_Skin * */
+						$skin                    = $upgrader_instance->skin;
 						$multi_plugin_update     = $single_plugin_update = FALSE;
 						$upgrading_active_plugin = FALSE; // Initialize.
 
@@ -2051,7 +2053,7 @@ namespace quick_cache
 								}
 							unset($_plugin); // Housekeeping.
 						}
-						else if($single_plugin_update && $upgrader_instance->skin->plugin_active == TRUE)
+						else if($single_plugin_update && $skin->plugin_active == TRUE)
 							$upgrading_active_plugin = TRUE;
 
 						if($upgrading_active_plugin)


### PR DESCRIPTION
Resolves websharks/quick-cache#327
