### PR TITLE
Fix a white screen related to DONOTCACHEPAGE.

### DIFF
--- a/quick-cache/includes/advanced-cache.tpl.php
+++ b/quick-cache/includes/advanced-cache.tpl.php
@@ -660,8 +660,17 @@ namespace quick_cache
 			if(isset($_SERVER['QUICK_CACHE_ALLOWED']) && !$_SERVER['QUICK_CACHE_ALLOWED'])
 				return $this->maybe_set_debug_info($this::NC_DEBUG_QUICK_CACHE_ALLOWED_SERVER_VAR);
 
-			if(defined('DONOTCACHEPAGE'))
-				return $this->maybe_set_debug_info($this::NC_DEBUG_DONOTCACHEPAGE_CONSTANT);
+			if(defined('DONOTCACHEPAGE')) {
+        if (DONOTCACHEPAGE) {
+          return $this->maybe_set_debug_info($this::NC_DEBUG_DONOTCACHEPAGE_CONSTANT);
+        }
+      } else {
+        // If someone defines DONOTCACHEPAGE to *true* between now and the moment
+        // output_buffer_callback_handler is called, we'll get a white screen.
+        // So, we define it here.
+        define('DONOTCACHEPAGE', false);
+      }
+
 
 			if(isset($_SERVER['DONOTCACHEPAGE']))
 				return $this->maybe_set_debug_info($this::NC_DEBUG_DONOTCACHEPAGE_SERVER_VAR);
@@ -864,7 +873,7 @@ namespace quick_cache
 			if(isset($_SERVER['QUICK_CACHE_ALLOWED']) && !$_SERVER['QUICK_CACHE_ALLOWED'])
 				return (boolean)$this->maybe_set_debug_info($this::NC_DEBUG_QUICK_CACHE_ALLOWED_SERVER_VAR);
 
-			if(defined('DONOTCACHEPAGE')) // WP Super Cache compatible.
+			if(defined('DONOTCACHEPAGE') && DONOTCACHEPAGE) // WP Super Cache compatible.
 				return (boolean)$this->maybe_set_debug_info($this::NC_DEBUG_DONOTCACHEPAGE_CONSTANT);
 
 			if(isset($_SERVER['DONOTCACHEPAGE'])) // WP Super Cache compatible.


### PR DESCRIPTION
When DONOTCACHEPAGE is defined by a plugin (e.g. in an init hook), Quick Cache
serves an empty page. This happens because:
At startup, if DONOTCACHEPAGE isn't defined, an object buffer is created.
This happens before the 'init' action, and before any plugin is loaded.
At shutdown, if DONOTCACHEPAGE isn't defined, this same buffer is printed.
If DONOTCACHEPAGE isn't defined at startup, but is defined at shutdown,
then the page's contents are in a buffer, but that buffer isn't being printed.

The fix defines DONOTCACHEPAGE to false, if it's not already defined.
This stops other plugins from defining it to true between startup and shutdown.

fixes #340 
